### PR TITLE
Add initial EMR cluster Terraform module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Azavea Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,99 @@
+# terraform-aws-emr-cluster
+
+A Terraform module to create an Amazon Web Services (AWS) Elastic MapReduce (EMR) cluster.
+
+## Usage
+
+```hcl
+data "template_file" "emr_configurations" {
+  template = "${file("configurations/default.json")}"
+}
+
+module "emr" {
+  source = "github.com/azavea/terraform-aws-emr-cluster?ref=0.1.0"
+
+  name          = "DatarpocCluster"
+  vpc_id        = "vpc-20f74844"
+  release_label = "emr-5.8.0"
+
+  applications = [
+    "Hadoop",
+    "Ganglia",
+    "Spark",
+    "Zeppelin",
+  ]
+
+  configurations = "${data.template_file.emr_configurations.rendered}"
+  key_name       = "hector"
+  subnet_id      = "subnet-e3sdf343"
+
+  instance_groups = [
+    {
+      name           = "MasterInstanceGroup"
+      instance_role  = "MASTER"
+      instance_type  = "m3.xlarge"
+      instance_count = 1
+    },
+    {
+      name           = "CoreInstanceGroup"
+      instance_role  = "CORE"
+      instance_type  = "m3.xlarge"
+      instance_count = "1"
+      bid_price      = "0.30"
+    },
+  ]
+
+  bootstrap_name = "runif"
+  bootstrap_uri  = "s3://elasticmapreduce/bootstrap-actions/run-if"
+  bootstrap_args = []
+  log_uri        = "s3://..."
+
+  project     = "Something"
+  environment = "Staging"
+}
+```
+
+## Variables
+
+- `name` - Name of EMR cluster
+- `vpc_id` - ID of VPC meant to house cluster
+- `release_label` - EMR release version to use (default: `emr-5.8.0`)
+- `applications` - A list of EMR release applications (default: `["Spark"]`)
+- `configurations` - JSON array of EMR application configurations
+- `key_name` - EC2 Key pair name
+- `subnet_id` - Subnet used to house the EMR nodes
+- `instance_groups` - List of objects for each desired instance group (see section below)
+- `bootstrap_name` - Name for the bootstrap action
+- `bootstrap_uri` - S3 URI for the bootstrap action script
+- `bootstrap_args` - A list of arguments to the bootstrap action script (default: `[]`)
+- `log_uri` - S3 URI of the EMR log destination
+- `project` - Name of project this cluster is for (default: `Unknown`)
+- `environment` - Name of environment this cluster is targeting (default: `Unknown`)
+
+## Instance Group Example
+
+```hcl
+[
+    {
+      name           = "MasterInstanceGroup"
+      instance_role  = "MASTER"
+      instance_type  = "m3.xlarge"
+      instance_count = 1
+    },
+    {
+      name           = "CoreInstanceGroup"
+      instance_role  = "CORE"
+      instance_type  = "m3.xlarge"
+      instance_count = "1"
+      bid_price      = "0.30"
+    },
+]
+```
+
+## Outputs
+
+- `id` - The EMR cluster ID
+- `name` - The EMR cluster name
+- `master_public_dns` - The EMR master public FQDN
+- `master_security_group_id` - Security group ID of the master instance/s
+- `slave_security_group_id` - Security group ID of the slave instance/s

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,122 @@
+#
+# EMR IAM resources
+#
+data "aws_iam_policy_document" "emr_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["elasticmapreduce.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "emr_service_role" {
+  name               = "emr${var.environment}ServiceRole"
+  assume_role_policy = "${data.aws_iam_policy_document.emr_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "emr_service_role" {
+  role       = "${aws_iam_role.emr_service_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole"
+}
+
+#
+# EMR IAM resources for EC2
+#
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "emr_ec2_instance_profile" {
+  name               = "${var.environment}JobFlowInstanceProfile"
+  assume_role_policy = "${data.aws_iam_policy_document.ec2_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "emr_ec2_instance_profile" {
+  role       = "${aws_iam_role.emr_ec2_instance_profile.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "emr_ec2_instance_profile" {
+  name = "${aws_iam_role.emr_ec2_instance_profile.name}"
+  role = "${aws_iam_role.emr_ec2_instance_profile.name}"
+}
+
+#
+# Security group resources
+#
+resource "aws_security_group" "emr_master" {
+  vpc_id = "${var.vpc_id}"
+
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+
+  tags {
+    Name        = "sg${var.name}Master"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_security_group" "emr_slave" {
+  vpc_id = "${var.vpc_id}"
+
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+
+  tags {
+    Name        = "sg${var.name}Slave"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# EMR resources
+#
+resource "aws_emr_cluster" "cluster" {
+  name           = "${var.name}"
+  release_label  = "${var.release_label}"
+  applications   = "${var.applications}"
+  configurations = "${var.configurations}"
+
+  ec2_attributes {
+    key_name                          = "${var.key_name}"
+    subnet_id                         = "${var.subnet_id}"
+    emr_managed_master_security_group = "${aws_security_group.emr_master.id}"
+    emr_managed_slave_security_group  = "${aws_security_group.emr_slave.id}"
+    instance_profile                  = "${aws_iam_instance_profile.emr_ec2_instance_profile.arn}"
+  }
+
+  instance_group = "${var.instance_groups}"
+
+  bootstrap_action {
+    path = "${var.bootstrap_uri}"
+    name = "${var.bootstrap_name}"
+    args = "${var.bootstrap_args}"
+  }
+
+  log_uri      = "${var.log_uri}"
+  service_role = "${aws_iam_role.emr_service_role.arn}"
+
+  tags {
+    Name        = "${var.name}"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  value = "${aws_emr_cluster.cluster.id}"
+}
+
+output "name" {
+  value = "${aws_emr_cluster.cluster.name}"
+}
+
+output "master_public_dns" {
+  value = "${aws_emr_cluster.cluster.master_public_dns}"
+}
+
+output "master_security_group_id" {
+  value = "${aws_security_group.emr_master.id}"
+}
+
+output "slave_security_group_id" {
+  value = "${aws_security_group.emr_slave.id}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,57 @@
+variable "project" {
+  default = "Unknown"
+}
+
+variable "environment" {
+  default = "Unknown"
+}
+
+variable "name" {}
+
+variable "vpc_id" {}
+
+variable "release_label" {
+  default = "emr-5.8.0"
+}
+
+variable "applications" {
+  default = ["Spark"]
+  type    = "list"
+}
+
+variable "configurations" {}
+
+variable "key_name" {}
+
+variable "subnet_id" {}
+
+variable "instance_groups" {
+  default = [
+    {
+      name           = "MasterInstanceGroup"
+      instance_role  = "MASTER"
+      instance_type  = "m3.xlarge"
+      instance_count = 1
+    },
+    {
+      name           = "CoreInstanceGroup"
+      instance_role  = "CORE"
+      instance_type  = "m3.xlarge"
+      instance_count = "1"
+      bid_price      = "0.30"
+    },
+  ]
+
+  type = "list"
+}
+
+variable "bootstrap_name" {}
+
+variable "bootstrap_uri" {}
+
+variable "bootstrap_args" {
+  default = []
+  type    = "list"
+}
+
+variable "log_uri" {}


### PR DESCRIPTION
Use Terraform configuration to define all of the AWS resources needed to
support an Amazon EMR cluster. This includes:

- IAM roles for cluster instances
- Skeleton security groups for the cluster instances
- The EMR cluster itself

Resolves https://github.com/azavea/operations/issues/128

---

**Testing**

See testing instructions for https://github.com/azavea/raster-foundry-deployment/pull/93.