### PR TITLE
Enable revoke_rules_on_delete setting for security group resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ module "emr" {
 
   name          = "DatarpocCluster"
   vpc_id        = "vpc-20f74844"
-  release_label = "emr-5.8.0"
+  release_label = "emr-5.9.0"
 
   applications = [
     "Hadoop",
@@ -32,7 +32,7 @@ module "emr" {
       name           = "MasterInstanceGroup"
       instance_role  = "MASTER"
       instance_type  = "m3.xlarge"
-      instance_count = 1
+      instance_count = "1"
     },
     {
       name           = "CoreInstanceGroup"
@@ -46,7 +46,7 @@ module "emr" {
   bootstrap_name = "runif"
   bootstrap_uri  = "s3://elasticmapreduce/bootstrap-actions/run-if"
   bootstrap_args = []
-  log_uri        = "s3://..."
+  log_uri        = "s3n://.../"
 
   project     = "Something"
   environment = "Staging"
@@ -66,7 +66,7 @@ module "emr" {
 - `bootstrap_name` - Name for the bootstrap action
 - `bootstrap_uri` - S3 URI for the bootstrap action script
 - `bootstrap_args` - A list of arguments to the bootstrap action script (default: `[]`)
-- `log_uri` - S3 URI of the EMR log destination
+- `log_uri` - S3 URI of the EMR log destination, must begin with `s3n://` and end with trailing slashes
 - `project` - Name of project this cluster is for (default: `Unknown`)
 - `environment` - Name of environment this cluster is targeting (default: `Unknown`)
 

--- a/main.tf
+++ b/main.tf
@@ -59,11 +59,8 @@ resource "aws_iam_instance_profile" "emr_ec2_instance_profile" {
 # Security group resources
 #
 resource "aws_security_group" "emr_master" {
-  vpc_id = "${var.vpc_id}"
-
-  lifecycle {
-    ignore_changes = ["ingress", "egress"]
-  }
+  vpc_id                 = "${var.vpc_id}"
+  revoke_rules_on_delete = true
 
   tags {
     Name        = "sg${var.name}Master"
@@ -73,11 +70,8 @@ resource "aws_security_group" "emr_master" {
 }
 
 resource "aws_security_group" "emr_slave" {
-  vpc_id = "${var.vpc_id}"
-
-  lifecycle {
-    ignore_changes = ["ingress", "egress"]
-  }
+  vpc_id                 = "${var.vpc_id}"
+  revoke_rules_on_delete = true
 
   tags {
     Name        = "sg${var.name}Slave"


### PR DESCRIPTION
Ensure that the `revoke_rules_on_delete` setting is enabled for security group resources in this module. This helps avoid an issue on infrastructure destruction where EMR managed security groups cannot be destroyed due to cyclic security group rules.

---

**Testing**

I tested a `plan`, `apply` and `destroy` cycle with the following TCL:

```tcl
provider "aws" {
  version = "~> 1.2"
  region  = "us-east-1"
}

provider "template" {
  version = "~> 1.0"
}

resource "aws_security_group_rule" "emr_master_ssh_ingress" {
  type              = "ingress"
  from_port         = "22"
  to_port           = "22"
  protocol          = "tcp"
  cidr_blocks       = [".../32"]
  security_group_id = "${module.emr.master_security_group_id}"
}

resource "aws_security_group_rule" "emr_master_all_egress" {
  type              = "egress"
  from_port         = "0"
  to_port           = "0"
  protocol          = "-1"
  cidr_blocks       = ["0.0.0.0/0"]
  security_group_id = "${module.emr.master_security_group_id}"
}

resource "aws_security_group_rule" "emr_slave_all_egress" {
  type              = "egress"
  from_port         = "0"
  to_port           = "0"
  protocol          = "-1"
  cidr_blocks       = ["0.0.0.0/0"]
  security_group_id = "${module.emr.slave_security_group_id}"
}

data "template_file" "emr_configurations" {
  template = "${file("configurations/default.json")}"
}

module "emr" {
  source = "github.com/azavea/terraform-aws-emr-cluster?ref=feature%2Fhmc%2Ffix-destroy"

  name          = "Cluster"
  vpc_id        = "vpc-..."
  release_label = "emr-5.9.0"

  applications = [
    "Hadoop",
    "Ganglia",
    "Spark",
  ]

  configurations = "${data.template_file.emr_configurations.rendered}"
  key_name       = "..."
  subnet_id      = "subnet-..."

  instance_groups = [
    {
      name           = "MasterInstanceGroup"
      instance_role  = "MASTER"
      instance_type  = "m3.xlarge"
      instance_count = "1"
    },
    {
      name           = "CoreInstanceGroup"
      instance_role  = "CORE"
      instance_type  = "m3.xlarge"
      instance_count = "2"
      bid_price      = "0.30"
    },
  ]

  bootstrap_name = "runif"
  bootstrap_uri  = "s3://elasticmapreduce/bootstrap-actions/run-if"
  bootstrap_args = ["instance.isMaster=true", "echo running on master node"]

  log_uri     = "s3n://.../"
  project     = "Test"
  environment = "Test"
}
```