### PR TITLE
Configure ServiceAccessSecurityGroup in EMR instances if subnet is private

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,6 +80,26 @@ resource "aws_security_group" "emr_slave" {
   }
 }
 
+resource "aws_security_group_rule" "master_allow_all_egress" {
+  type            = "egress"
+  from_port       = 0
+  to_port         = 65535
+  protocol        = "all"
+  cidr_blocks     = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.emr_master.id}"
+}
+
+resource "aws_security_group_rule" "slave_allow_all_egress" {
+  type            = "egress"
+  from_port       = 0
+  to_port         = 65535
+  protocol        = "all"
+  cidr_blocks     = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.emr_slave.id}"
+}
+
 #
 # EMR resources
 #


### PR DESCRIPTION
This security group will be created but not configured in the instances if subnet is public. It has to be created regardless as I could not find a better way to conditionally support both public and private subnets